### PR TITLE
Fix password change and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ EXAMPLES
     Add the user account jsmith with email address john.smith@example.com,
     display name John Smith, and password hunter1.
 
-  lldap-cli user update john.smith@example.com password hunter2
+  lldap-cli user update set john.smith@example.com password hunter2
     Set the account password of the user with email address
     john.smith@example.com to hunter2.
 

--- a/lldap-cli
+++ b/lldap-cli
@@ -965,7 +965,7 @@ EXAMPLES
     Add the user account jsmith with email address john.smith@example.com,
     display name John Smith, and password hunter1.
 
-  $name user update john.smith@example.com password hunter2
+  $name user update set john.smith@example.com password hunter2
     Set the account password of the user with email address
     john.smith@example.com to hunter2.
 
@@ -1157,7 +1157,7 @@ case "$1" in
             exit 1
           fi
           if [ "$5" ]; then
-            userPassword="$4"
+            userPassword="$5"
           else
             echo -n "New user password: "
             read -s userPassword


### PR DESCRIPTION
There is a critical flaw in the script when changing the user password.
If the user password is changed and the new password is provided as an argument (not via interactive input) it will be set to `password` no matter what new password was provided.

I also fixed the documentation to close #6, because it is kind of on-topic.