### PR TITLE
Added newline before appending custom attributes to user attribute list

### DIFF
--- a/lldap-cli
+++ b/lldap-cli
@@ -209,7 +209,7 @@ listUserAttributes() {
   list="$(echo "$list" | head -n-1)"
 
   if result="$(runQuery "$query" "$variables")"; then
-    list+="$(echo "$result" | jq '.data.user.attributes[].name' | tr -d '"')"
+    list+=$'\n'"$(echo "$result" | jq '.data.user.attributes[].name' | tr -d '"')"
     list="$(echo "$list" | sort)"
     echo "$list"
   fi

--- a/lldap-cli
+++ b/lldap-cli
@@ -209,7 +209,7 @@ listUserAttributes() {
   list="$(echo "$list" | head -n-1)"
 
   if result="$(runQuery "$query" "$variables")"; then
-    list+=$'\n'"$(echo "$result" | jq '.data.user.attributes[].name' | tr -d '"')"
+    list+="$(echo $'\\n'"$result" | jq '.data.user.attributes[].name' | tr -d '"')"
     list="$(echo "$list" | sort)"
     echo "$list"
   fi


### PR DESCRIPTION
As per #3 , when running `user attributes list <user>`, some attributes wouldn't add a newline before being displayed, leading to the final line containing multiple attributes (`uuidavatar` in my case)

It looks like this occurs for attributes obtained via the `runQuery` call in `listUserAttributes` - I've added a newline to the list construction in there. This seems to resolve it for a single `runQuery` attribute, though I haven't tested it for multiple.