### PR TITLE
reset OPTIND for stacked calls of getopts

### DIFF
--- a/lldap-cli
+++ b/lldap-cli
@@ -1117,6 +1117,7 @@ case "$1" in
         email="$3"
         password= displayname= firstname= lastname=
         shift 3
+        OPTIND=1
         while getopts 'p:Pd:f:l:a:' opt; do
           case "$opt" in
             p) userPassword="$OPTARG" ;;
@@ -1248,6 +1249,7 @@ case "$1" in
                 attribute="$2"
                 attributeType="$3"
                 shift 3
+                OPTIND=1
                 attributeIsList=false
                 attributeIsVisible=false
                 attributeIsEditable=false


### PR DESCRIPTION
At least in my tests the script was ignoring the flags parsed with `getopts` for subcommands like `user add`.
Resetting `OPTIND` worked great in my scenarios 


I tested it on bash version `5.2.26(1)-release`.